### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Publish Package to npmjs
+permissions:
+  contents: write
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/dynolabs/strapi-provider-mailersend/security/code-scanning/2](https://github.com/dynolabs/strapi-provider-mailersend/security/code-scanning/2)

To address the issue, we need to set the `permissions` key for the workflow/job in `.github/workflows/release.yml`. This can be added:

- At the workflow root (applies to all jobs).
- Or, inside the `jobs.release` block (applies only to that job).

Because there is only one job, and for clarity and future-proofing, it is recommended to add `permissions:` at the top level (under the workflow `name`), specifying the least privilege required. For semantic-release to create releases and tags, `contents: write` is the minimum necessary. If you use features such as commenting on issues or pull requests, those permissions should be added, but nothing in the shown workflow suggests that.

Therefore, add at the top level:
```yaml
permissions:
  contents: write
```
It should go immediately after the `name:` field and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
